### PR TITLE
Flush buffer when match both `start` and `end`

### DIFF
--- a/lib/fluent/plugin/filter_concat.rb
+++ b/lib/fluent/plugin/filter_concat.rb
@@ -76,10 +76,12 @@ module Fluent
       new_es = MultiEventStream.new
       es.each do |time, record|
         begin
-          new_time, new_record = process(tag, time, record)
-          if new_record
-            time = new_time if @use_first_timestamp
-            new_es.add(time, record.merge(new_record))
+          flushed_es = process(tag, time, record)
+          unless flushed_es.empty?
+            flushed_es.each do |_time, new_record|
+              time = _time if @use_first_timestamp
+              new_es.add(time, record.merge(new_record))
+            end
           end
         rescue => e
           router.emit_error_event(tag, time, record, e)
@@ -97,6 +99,7 @@ module Fluent
     end
 
     def process(tag, time, record)
+      new_es = MultiEventStream.new
       if @stream_identity_key
         stream_identity = "#{tag}:#{record[@stream_identity_key]}"
       else
@@ -107,30 +110,49 @@ module Fluent
       when :line
         @buffer[stream_identity] << [tag, time, record]
         if @buffer[stream_identity].size >= @n_lines
-          return flush_buffer(stream_identity)
+          new_time, new_record = flush_buffer(stream_identity)
+          time = new_time if @use_first_timestamp
+          new_es.add(time, new_record)
+          return new_es
         end
       when :regexp
         case
         when firstline?(record[@key])
           if @buffer[stream_identity].empty?
             @buffer[stream_identity] << [tag, time, record]
-            return flush_buffer(stream_identity) if lastline?(record[@key])
+            if lastline?(record[@key])
+              new_time, new_record = flush_buffer(stream_identity)
+              time = new_time if @use_first_timestamp
+              new_es.add(time, new_record)
+            end
           else
-            return flush_buffer(stream_identity, [tag, time, record])
+            new_time, new_record = flush_buffer(stream_identity, [tag, time, record])
+            time = new_time if @use_first_timestamp
+            new_es.add(time, new_record)
+            if lastline?(record[@key])
+              new_time, new_record = flush_buffer(stream_identity)
+              time = new_time if @use_first_timestamp
+              new_es.add(time, new_record)
+            end
+            return new_es
           end
         when lastline?(record[@key])
           @buffer[stream_identity] << [tag, time, record]
-          return flush_buffer(stream_identity)
+          new_time, new_record = flush_buffer(stream_identity)
+          time = new_time if @use_first_timestamp
+          new_es.add(time, new_record)
+          return new_es
         else
           if @buffer[stream_identity].empty?
-            return [time, record]
+            new_es.add(time, record)
+            return new_es
           else
             # Continuation of the previous line
             @buffer[stream_identity] << [tag, time, record]
           end
         end
       end
-      nil
+      new_es
     end
 
     def firstline?(text)

--- a/lib/fluent/plugin/filter_concat.rb
+++ b/lib/fluent/plugin/filter_concat.rb
@@ -110,18 +110,18 @@ module Fluent
           return flush_buffer(stream_identity)
         end
       when :regexp
-        if firstline?(record[@key])
+        case
+        when firstline?(record[@key])
           if @buffer[stream_identity].empty?
             @buffer[stream_identity] << [tag, time, record]
+            return flush_buffer(stream_identity) if lastline?(record[@key])
           else
             return flush_buffer(stream_identity, [tag, time, record])
           end
-        end
-        if lastline?(record[@key])
-          @buffer[stream_identity] << [tag, time, record] unless firstline?(record[@key])
+        when lastline?(record[@key])
+          @buffer[stream_identity] << [tag, time, record]
           return flush_buffer(stream_identity)
-        end
-        if !firstline?(record[@key]) && !lastline?(record[@key])
+        else
           if @buffer[stream_identity].empty?
             return [time, record]
           else

--- a/test/plugin/test_filter_concat.rb
+++ b/test/plugin/test_filter_concat.rb
@@ -320,6 +320,33 @@ class FilterConcatTest < Test::Unit::TestCase
       assert_equal(expected, filtered)
     end
 
+    # https://github.com/okkez/fluent-plugin-concat/issues/14
+    def test_multiline_start_end_regexp_github14
+      config = <<-CONFIG
+        key message
+        stream_identity_key container_id
+        multiline_start_regexp /^start/
+        multiline_end_regexp /end$/
+      CONFIG
+      messages = [
+        { "container_id" => "1", "message" => "start message1 end" },
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "1", "message" => " message3" },
+        { "container_id" => "1", "message" => "start message2 end" },
+        { "container_id" => "1", "message" => "start" },
+        { "container_id" => "1", "message" => " message4" },
+        { "container_id" => "1", "message" => "end" },
+      ]
+      expected = [
+        { "container_id" => "1", "message" => "start message1 end" },
+        { "container_id" => "1", "message" => "start\n message3" },
+        { "container_id" => "1", "message" => "start message2 end" },
+        { "container_id" => "1", "message" => "start\n message4\nend" },
+      ]
+      filtered = filter(config, messages)
+      assert_equal(expected, filtered)
+    end
+
     def test_timeout
       config = <<-CONFIG
         key message


### PR DESCRIPTION
Fix #14